### PR TITLE
Bug css overlay ml

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,10 @@
         <img class='drop-down-toggle' src="./assets/menu-close.svg" alt="menu-close">
         <h3 class="header-text white-text">IdeaBox</h3>
       </div>
+      <hr class="horse-rule">
       <p class = "purple-grey-text">Filter Starred Ideas</p>
       <button class="header-text white-text purple-3">Show Starred Ideas</button>
+      <hr class="horse-rule">
     </section>
 
     <main>

--- a/index.html
+++ b/index.html
@@ -88,5 +88,6 @@
       </section>
     </main>
   </body>
+  <script src="./src/idea.js"> </script>
   <script src="./src/main.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="https://fonts.googleapis.com/css?family=Open%20Sans" rel='stylesheet'>
     <link rel="stylesheet" type="text/css" href="./styles.css">
   </head>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
           <p class="header-text">Body</p>
           <input class='border-top' id="body-input" type="text" name="" value="">
         </div>
-        <button class="header-text purple-5 light-text border-top" type="button" name="button">Save</button>
+        <button class="header-text purple-5 light-text border-top" id='save-button' type="button" name="button">Save</button>
         <div class="search-ideas border-top">
           <div class='purple-5' type="button" name="button"> <img src="./assets/search.svg" alt="">
           </div>

--- a/src/idea.js
+++ b/src/idea.js
@@ -4,8 +4,10 @@ class Idea  {
     this.title = title;
     this.body = body;
     this.star = false;
+    this.node;
 
   };
+
   saveToStorage(){
 
 
@@ -24,11 +26,12 @@ class Idea  {
   createHtml(){
     var starIcon
     if(this.star){
+      
       starIcon = "./assets/star-active.svg"
     } else {
       starIcon = "./assets/star.svg"
-    }
-    return `<div class="ideas">
+    }  
+    return `<div id = "${this.id}" class="ideas">
       <div class="idea-top purple-4">
         <img src="${starIcon}" alt="star icon">
         <img src="./assets/delete.svg" alt="delete icon">

--- a/src/idea.js
+++ b/src/idea.js
@@ -6,6 +6,43 @@ class Idea  {
     this.star = false;
 
   };
+  saveToStorage(){
 
+
+  }
+  deleteFromStorage(){
+
+
+  }
+  updateIdea(title, body, star){
+    this.title = title;
+    this.body = body;
+    this.star = star;
+
+
+  }
+  createHtml(){
+    var starIcon
+    if(this.star){
+      starIcon = "./assets/star-active.svg"
+    } else {
+      starIcon = "./assets/star.svg"
+    }
+    return `<div class="ideas">
+      <div class="idea-top purple-4">
+        <img src="${starIcon}" alt="star icon">
+        <img src="./assets/delete.svg" alt="delete icon">
+      </div>
+      <div class="idea-text white-background">
+        <h4 class="header-text">${this.title}</h4>
+        <p class="body-text">${this.body}</p>
+      </div>
+      <div class="idea-bottom purple-3">
+          <img src="./assets/comment.svg" alt="">
+          <p class="body-text">Comment</p>
+      </div>
+    </div>`
+
+  }
 }
 // module.exports = Idea

--- a/src/idea.js
+++ b/src/idea.js
@@ -1,0 +1,11 @@
+class Idea  {
+  constructor(title, body){
+    this.id = Date.now()
+    this.title = title;
+    this.body = body;
+    this.star = false;
+
+  };
+
+}
+// module.exports = Idea

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+var ideaArray = [];
+
 var buttonSave = document.querySelector('#save-button');
 var ideaCards = document.querySelector('.idea-cards');
 var inputTitle = document.querySelector('#title-input');
@@ -18,11 +20,14 @@ window.onload = checkButtonStatus;
 ;function insertIdea() {
   var newTitle = inputTitle.value;
   var newBody = inputBody.value;
-  if( newTitle !== '' && newBody !== '' ) {
+  if(newTitle !== '' && newBody !== '') {
     inputTitle.value = '';
     inputBody.value = '';
-    ideaCards.innerHTML += new Idea(newTitle, newBody).createHtml();
+    var idea = new Idea(newTitle, newBody);
+    ideaCards.innerHTML += idea.createHtml();
+    ideaArray.push(idea);
     checkButtonStatus();
+    idea.node = document.querySelector(`#${idea.id}`);
   };
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ var imgHamburgerIcon = document.querySelectorAll('.drop-down-toggle');
 var sectionDefaultMenu = document.querySelector('.menu');
 var sectionDropDownMenu = document.querySelector('.drop-down');
 var divOverlay = document.querySelector('.overlay');
+var ideaCards = document.querySelector('.idea-cards');
 
 imgHamburgerIcon[0].addEventListener('click', toggleDropDown);
 imgHamburgerIcon[1].addEventListener('click', toggleDropDown);
@@ -12,3 +13,4 @@ imgHamburgerIcon[1].addEventListener('click', toggleDropDown);
   sectionDropDownMenu.classList.toggle('hidden');
   divOverlay.classList.toggle('hidden');
 };
+var idea = new Idea ("example", "bret")

--- a/src/main.js
+++ b/src/main.js
@@ -1,16 +1,29 @@
+var buttonSave = document.querySelector('#save-button');
+var ideaCards = document.querySelector('.idea-cards');
+var inputTitle = document.querySelector('#title-input');
+var inputBody = document.querySelector('#body-input');
 var imgHamburgerIcon = document.querySelectorAll('.drop-down-toggle');
 var sectionDefaultMenu = document.querySelector('.menu');
 var sectionDropDownMenu = document.querySelector('.drop-down');
 var divOverlay = document.querySelector('.overlay');
-var ideaCards = document.querySelector('.idea-cards');
 
+buttonSave.addEventListener('click', insertIdea)
 imgHamburgerIcon[0].addEventListener('click', toggleDropDown);
 imgHamburgerIcon[1].addEventListener('click', toggleDropDown);
 
+
+;function insertIdea() {
+  var newTitle = inputTitle.value;
+  var newBody = inputBody.value;
+  if( newTitle !== '' && newBody !== '' ) {
+    ideaCards.innerHTML += new Idea(newTitle, newBody).createHtml();
+  };
+};
 
 ;function toggleDropDown() {
   sectionDefaultMenu.classList.toggle('hidden');
   sectionDropDownMenu.classList.toggle('hidden');
   divOverlay.classList.toggle('hidden');
 };
+
 var idea = new Idea ("example", "bret")

--- a/src/main.js
+++ b/src/main.js
@@ -10,15 +10,29 @@ var divOverlay = document.querySelector('.overlay');
 buttonSave.addEventListener('click', insertIdea)
 imgHamburgerIcon[0].addEventListener('click', toggleDropDown);
 imgHamburgerIcon[1].addEventListener('click', toggleDropDown);
+inputTitle.addEventListener('keyup', checkButtonStatus);
+inputBody.addEventListener('keyup', checkButtonStatus);
 
+window.onload = checkButtonStatus;
 
 ;function insertIdea() {
   var newTitle = inputTitle.value;
   var newBody = inputBody.value;
   if( newTitle !== '' && newBody !== '' ) {
+    inputTitle.value = '';
+    inputBody.value = '';
     ideaCards.innerHTML += new Idea(newTitle, newBody).createHtml();
+    checkButtonStatus();
   };
 };
+
+;function checkButtonStatus() {
+  if (inputTitle.value === '' || inputBody.value === '') {
+    buttonSave.disabled = true;
+  } else {
+    buttonSave.disabled = false;
+  }
+}
 
 ;function toggleDropDown() {
   sectionDefaultMenu.classList.toggle('hidden');

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,7 @@ html, body, h1, h2, h3, h4, h5, h6, p {
 
 html, body {
   height: 100%;
+  width: 100%;
 }
 
 body {
@@ -18,6 +19,12 @@ body {
   font-size: 16px;
 }
 
+main{
+  position: absolute;
+  top: 65px;
+  width: 100%;
+}
+
 #main-title {
   padding: .6em;
 }
@@ -27,10 +34,10 @@ body {
   display: flex;
   flex-direction: column;
 }
+
 .idea-form>div,
 .idea-form>button {
   margin: .5em 0;
-
 }
 
 .idea-form>button {
@@ -78,16 +85,14 @@ body {
   left: .55em;
   width: 1.4em;
   height: auto;
-
 }
 
 .search-ideas input {
   height: auto;
   width: auto;
   grid-column: 2;
-
-
 }
+
 .idea-cards{
   padding:0 .9375em ;
 }
@@ -127,6 +132,7 @@ body {
 h3 {
   text-align: center;
 }
+
 .overlay{
   width: 100%;
   height: 100%;
@@ -160,10 +166,12 @@ h3 {
 .purple-6 {
   background: #6E646b;
 }
+
 .purple-grey-text{
   color: #bfbfdd;
   font-weight: 600;
 }
+
 .white-background {
   background: #ffffff;
 }
@@ -208,8 +216,8 @@ h3 {
   width: 100%;
   position: relative;
 }
-.drop-down img,
 
+.drop-down img,
 .menu img{
   position: absolute;
   width: 2.8125em;
@@ -217,22 +225,23 @@ h3 {
   top: .6em;
   left: .5em;
 }
+
 .drop-down{
+  position: relative;
   padding-top: .875em;
   padding-bottom: .875em;
   width: 100%;
   display: grid;
   grid-template-rows: 1fr 1fr 1fr;
   grid-row-gap: 1.2em;
-
-
+  z-index: 11;
 }
+
 .drop-down p,
 .drop-down button{
   margin:0 .9375rem;
-
-
 }
+
 /*=== main section ===*/
 
 .ideas {
@@ -249,59 +258,53 @@ h3 {
   flex-grow: 3;
 }
 
-
 .hidden{
   display: none;
 }
+
 .horse-rule{
   display: none;
 }
 /*=== media queries ===*/
 
-/* @media only screen and (max-width: 400px) {
-  body {
-    flex-direction: column;
-  }
-
-  .header-text {
-    font-size: 18px;
-    padding: 10px;
-  }
-
-  .menu {
-    height: 40px;
-    text-align: center;
-    width: 100%;
-  }
-
-  .idea-form {
-    flex-grow: 1;
-  }
-} */
-
 @media screen and (min-width: 900px)  {
+
+  body {
+    display: grid;
+    grid-template-columns: 20em 1fr;
+  }
+
   .drop-down {
     grid-column: 1;
     grid-row: 1 / span 2;
     display: flex ;
     flex-direction: column;
     align-content: flex-start;
-    /* text-align: left; */
-    /* justify-content: center; */
+    height: 100%;
   }
+
+  main {
+    position: static;
+    top: 0;
+    height: 100%;
+  }
+
   .horse-rule{
     display: block;
     width: 100%;
     opacity: 30%;
   }
+
   .drop-down h3{
     margin: 0;
     padding: 0 1.2rem;
     text-align: left;
   }
+
   .overlay{
     display: none;
   }
+
   .drop-down>p,
   .drop-down>button{
     margin: 1.2rem;
@@ -327,26 +330,19 @@ h3 {
     grid-template-columns: repeat(auto-fill, 17.9375em);
     grid-column-gap: 1.375em;
   }
-
-  body {
-    display: grid;
-    grid-template-columns: 20em 1fr;
-    grid-template-rows: 29.375em 1fr;
-
-  }
-
 }
+
 @media screen and (min-width: 1550px){
+
   body{
     font-size: 24px;
-
   }
+
   .header-text{
     font-size: 24px;
-
   }
+
   .body-text{
     font-size: 20px;
   }
-
 }

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,7 @@ body {
   width: 100%;
   font-style: "Open Sans";
   font-weight: 300;
+  font-size: 16px;
 }
 
 #main-title {
@@ -250,7 +251,7 @@ h3 {
 
 /*=== media queries ===*/
 
-@media only screen and (max-width: 400px) {
+/* @media only screen and (max-width: 400px) {
   body {
     flex-direction: column;
   }
@@ -269,4 +270,36 @@ h3 {
   .idea-form {
     flex-grow: 1;
   }
+} */
+
+@media screen and (min-width: 1200px) { 
+  .drop-down {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    display: grid;
+  }
+
+  .menu {
+    display: none;
+  }
+
+  .idea-form {
+    width: 100%;
+  }
+
+  .idea-cards {
+    display: grid;
+    width: 100%;
+    justify-content: center;
+    grid-template-columns: repeat(auto-fill, 17.9375em);
+    grid-column-gap: 1.375em;
+  }
+
+  body {
+    display: grid;
+    grid-template-columns: 20em 1fr;
+    grid-template-rows: 29.375em 1fr;
+    
+  }
+
 }

--- a/styles.css
+++ b/styles.css
@@ -248,7 +248,9 @@ h3 {
 .hidden{
   display: none;
 }
-
+.horse-rule{
+  display: none;
+}
 /*=== media queries ===*/
 
 /* @media only screen and (max-width: 400px) {
@@ -272,11 +274,37 @@ h3 {
   }
 } */
 
-@media screen and (min-width: 1200px) { 
+@media screen and (min-width: 900px)  {
   .drop-down {
     grid-column: 1;
     grid-row: 1 / span 2;
-    display: grid;
+    display: flex ;
+    flex-direction: column;
+    align-content: flex-start;
+    /* text-align: left; */
+    /* justify-content: center; */
+  }
+  .horse-rule{
+    display: block;
+    width: 100%;
+    opacity: 30%;
+  }
+  .drop-down h3{
+    margin: 0;
+    padding: 0 1.2rem;
+    text-align: left;
+  }
+  .overlay{
+    display: none;
+  }
+  .drop-down>p,
+  .drop-down>button{
+    margin: 1.2rem;
+    padding: .5em 0;
+  }
+
+  .drop-down-toggle{
+    display: none;
   }
 
   .menu {
@@ -284,7 +312,7 @@ h3 {
   }
 
   .idea-form {
-    width: 100%;
+    width: 96%;
   }
 
   .idea-cards {
@@ -299,7 +327,21 @@ h3 {
     display: grid;
     grid-template-columns: 20em 1fr;
     grid-template-rows: 29.375em 1fr;
-    
+
+  }
+
+}
+@media screen and (min-width: 1550px){
+  body{
+    font-size: 24px;
+
+  }
+  .header-text{
+    font-size: 24px;
+
+  }
+  .body-text{
+    font-size: 20px;
   }
 
 }

--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,11 @@ body {
   height: 2.5em;
 }
 
+.idea-form>button:disabled {
+  background-color: #5858a7;
+  cursor: not-allowed;
+}
+
 .idea-form p {
   padding: .375em 0;
 }


### PR DESCRIPTION
# Description

There were 2 separate bugs:
 -  The overlay that appears when the hamburger menu is clicked in mobile-view didn't extend to the bottom of the page
 -  The side-menu (called '.drop-down' in the CSS file) in desktop-view didn't extend to the bottom of the page.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

#### Bug 1
The reason bug #1 was appearing was because the overlay was set to take 100% height of it's container element, but it wasn't set up to recognize the `main` element as its container. This is due to a property of `position: absolute` looking for the first element with a `position` that isn't set to `static` (the default value).  

Setting `main` to `position: absolute` resolved this, and in order to keep the previous layout looking good, added some positioning styles as well as some conditional styles in the desktop-view.

#### Bug 2
The reason bug #2 was appearing had something to do with our row-gridding in `body`. I'm not exactly sure what was causing it, but removing the style `grid-template-rows` style from the body seemed to fix it.

Fixes # (issue)

## Type of change
 -Bug-fix

# How Has This Been Tested?

- Manually. Added cards, changed view several times.

# Checklist:

- [] Iteration 0
- [x] Iteration 1
- [] Iteration 2
- [] Iteration 3
- [] Iteration 4
- [] Iteration 5